### PR TITLE
Update ExchangeVersion.xml

### DIFF
--- a/officedocs-dev-exchange-ews-api/xml/Microsoft.Exchange.WebServices.Data/ExchangeVersion.xml
+++ b/officedocs-dev-exchange-ews-api/xml/Microsoft.Exchange.WebServices.Data/ExchangeVersion.xml
@@ -130,5 +130,24 @@
         <summary>Exchange Server 2013 Service Pack 1 (SP1).</summary>
       </Docs>
     </Member>
+      <Member MemberName="Exchange2016">
+      <MemberSignature Language="C#" Value="Exchange2016" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Microsoft.Exchange.WebServices.Data.ExchangeVersion Exchange2016 = int32(7)" />
+      <MemberSignature Language="DocId" Value="F:Microsoft.Exchange.WebServices.Data.ExchangeVersion.Exchange2016" />
+      <MemberSignature Language="VB.NET" Value="Exchange2016" />
+      <MemberSignature Language="C++ CLI" Value="Exchange2016" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>Microsoft.Exchange.WebServices</AssemblyName>
+        <AssemblyVersion>15.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Microsoft.Exchange.WebServices.Data.ExchangeVersion</ReturnType>
+      </ReturnValue>
+      <MemberValue>5</MemberValue>
+      <Docs>
+        <summary>Exchange Server 2016.</summary>
+      </Docs>
+    </Member>
   </Members>
 </Type>


### PR DESCRIPTION
Adding an extra member to the table, to include **Exchange2016** as a valid value.
This will help us deflect EWS support requests for the error message:
_The property Mentions is valid only for Exchange Exchange2015 or later versions._
